### PR TITLE
feat(ui): Make UI fully responsive for iPhone (header, cards, tabs, layout)

### DIFF
--- a/app/src/app/page.module.css
+++ b/app/src/app/page.module.css
@@ -369,4 +369,29 @@
   .page {
     overflow-x: hidden;
   }
+  .dataVizPlaceholder {
+    padding: 1rem 0.2rem;
+    font-size: 1rem;
+    width: 100%;
+    max-width: 100vw;
+    box-sizing: border-box;
+    overflow-x: hidden;
+    margin-left: 0;
+    margin-right: 0;
+  }
+  .contactForm {
+    max-width: 100vw;
+    width: 100%;
+    box-sizing: border-box;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+    margin-left: 0;
+    margin-right: 0;
+    overflow-x: hidden;
+  }
+  .input {
+    width: 100%;
+    box-sizing: border-box;
+    min-width: 0;
+  }
 }

--- a/app/src/app/page.module.css
+++ b/app/src/app/page.module.css
@@ -333,20 +333,20 @@
   }
   .cardRow {
     gap: 0.7rem;
-    width: 100vw;
+    width: 100%;
     box-sizing: border-box;
     margin-left: 0;
     margin-right: 0;
-    overflow-x: hidden;
+    overflow-x: visible;
   }
   .card {
     padding: 0.7rem 0.3rem;
-    max-width: 100vw;
+    max-width: 100%;
     width: 100%;
     min-width: 0;
     margin-bottom: 1rem;
     box-sizing: border-box;
-    overflow-x: hidden;
+    overflow-x: visible;
   }
   .cardTitle {
     font-size: 1.1rem;
@@ -362,32 +362,31 @@
   }
   .tabContent {
     padding: 0.5rem 0.1rem 0.1rem 0.1rem;
-    width: 100vw;
+    width: 100%;
     box-sizing: border-box;
-    overflow-x: hidden;
+    overflow-x: visible;
   }
   .page {
-    overflow-x: hidden;
+    overflow-x: visible;
   }
   .dataVizPlaceholder {
     padding: 1rem 0.2rem;
     font-size: 1rem;
     width: 100%;
-    max-width: 100vw;
     box-sizing: border-box;
-    overflow-x: hidden;
+    overflow-x: visible;
     margin-left: 0;
     margin-right: 0;
   }
   .contactForm {
-    max-width: 100vw;
+    max-width: 100%;
     width: 100%;
     box-sizing: border-box;
     padding-left: 0.2rem;
     padding-right: 0.2rem;
     margin-left: 0;
     margin-right: 0;
-    overflow-x: hidden;
+    overflow-x: visible;
   }
   .input {
     width: 100%;

--- a/app/src/app/page.module.css
+++ b/app/src/app/page.module.css
@@ -333,12 +333,20 @@
   }
   .cardRow {
     gap: 0.7rem;
+    width: 100vw;
+    box-sizing: border-box;
+    margin-left: 0;
+    margin-right: 0;
+    overflow-x: hidden;
   }
   .card {
     padding: 0.7rem 0.3rem;
-    max-width: 98vw;
+    max-width: 100vw;
+    width: 100%;
     min-width: 0;
     margin-bottom: 1rem;
+    box-sizing: border-box;
+    overflow-x: hidden;
   }
   .cardTitle {
     font-size: 1.1rem;
@@ -354,5 +362,11 @@
   }
   .tabContent {
     padding: 0.5rem 0.1rem 0.1rem 0.1rem;
+    width: 100vw;
+    box-sizing: border-box;
+    overflow-x: hidden;
+  }
+  .page {
+    overflow-x: hidden;
   }
 }

--- a/app/src/app/page.module.css
+++ b/app/src/app/page.module.css
@@ -299,3 +299,60 @@
     font-size: 1.3rem;
   }
 }
+@media (max-width: 430px) {
+  .header {
+    font-size: 1.3rem;
+    padding: 0.2rem 0 0.2rem 0;
+    min-height: 48px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+  .logoArea {
+    padding: 0.5rem 0 0.2rem 0;
+    gap: 0.5rem;
+  }
+  .logo {
+    font-size: 1.3rem;
+  }
+  .brand {
+    font-size: 1.1rem;
+  }
+  .navTabs {
+    gap: 0.2rem;
+    margin: 0.2rem 0 0.2rem 0;
+  }
+  .tabButton {
+    font-size: 0.85rem;
+    padding: 0.4rem 0.7rem;
+    border-radius: 1.2rem 1.2rem 0 0;
+  }
+  .main {
+    gap: 1rem;
+    padding-top: 0.5rem;
+  }
+  .cardRow {
+    gap: 0.7rem;
+  }
+  .card {
+    padding: 0.7rem 0.3rem;
+    max-width: 98vw;
+    min-width: 0;
+    margin-bottom: 1rem;
+  }
+  .cardTitle {
+    font-size: 1.1rem;
+  }
+  .cardDesc {
+    font-size: 0.95rem;
+  }
+  .heroTitle {
+    font-size: 1.1rem;
+  }
+  .sectionTitle {
+    font-size: 1rem;
+  }
+  .tabContent {
+    padding: 0.5rem 0.1rem 0.1rem 0.1rem;
+  }
+}


### PR DESCRIPTION
## What
This PR makes the UI fully responsive for iPhone and small mobile devices. It addresses:
- Header: More compact, sticky, and with smaller logo/brand for mobile
- Tabs: Smaller, more touch-friendly, and better spacing
- Cards/boxes: No longer larger than the header, fit the viewport, and have reduced padding
- General layout: Improved proportions and usability for iPhone screens

## Why
- The previous UI was not usable on iPhone: header was too big, boxes overflowed, and tabs were not touch-friendly.
- This PR ensures a professional, modern, and accessible experience on iPhone and small devices.

## How
- Added a new media query for max-width: 430px (iPhone typical width)
- Adjusted font sizes, paddings, gaps, and layout for header, logo, brand, navTabs, tabButton, main, cardRow, card, heroTitle, sectionTitle, and tabContent
- Made header sticky for better navigation UX

## Tests
- All frontend tests pass (`npm test`)
- Manual check on iPhone simulator and Chrome DevTools responsive mode

---
Closes # (if applicable)

Please review and merge if all looks good!